### PR TITLE
出品フォーム実装

### DIFF
--- a/app/assets/stylesheets/category1s.scss
+++ b/app/assets/stylesheets/category1s.scss
@@ -18,7 +18,7 @@
     .visible-pc {
       width: 700px;
       margin: 0 auto;
-      .gray {
+      .category-index__title {
         font-size: 22px;
         padding: 8px 0;
       }
@@ -79,11 +79,39 @@
               padding: 0 20px 10px;
               &__name {
                 padding: 0 20px 0 0;
-                  font-size: 14px;
-                  width: 275px;
-                  line-height: 16px;
-                  margin: 8px 0;
+                font-size: 14px;
+                width: 275px;
+                line-height: 16px;
+                margin: 8px 0;
+                display: inline-block;
+                .category23-all {
                   display: inline-block;
+                  text-decoration: none;
+                  color: #0099E8;
+                }
+                .category23-all:hover {
+                  text-decoration: underline;
+                }
+              }
+              
+            }
+          }
+          // brand_groupページ用
+          &__initial-box {
+            &__title {
+              font-size: 14px;
+              background-color: #EEEEEE;
+              padding: 10px 30px;
+            }
+            &__brand-list {
+              padding: 10px 50px;
+              &__name {
+                padding: 0 20px 0 0;
+                font-size: 14px;
+                width: 275px;
+                line-height: 16px;
+                margin: 8px 0;
+                display: inline-block;
                 .category23-all {
                   display: inline-block;
                   text-decoration: none;

--- a/app/controllers/brand_groups_controller.rb
+++ b/app/controllers/brand_groups_controller.rb
@@ -12,7 +12,7 @@ class BrandGroupsController < ApplicationController
   def initial_index(items)
     initials = []
     items.each do |item|
-      initials << {id: item.brand_id, initial: Brand.find(item.brand_id).brand_name.slice(0)}
+      initials << {initial: Brand.find(item.brand_id).brand_name.slice(0),id: item.brand_id }
     end
     initials.uniq!(&:first)
     return initials

--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -2,4 +2,5 @@ class BrandsController < ApplicationController
   def index
     @category1s = Category1.order("id ASC")
   end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,5 +3,39 @@ class ItemsController < ApplicationController
   def index
     @items = Item.all
   end
+
+  def new
+    @item = Item.new
+    @brand = Brand.new
+    @category1 = Category1.new
+    @category2 = Category2.new
+    @category3 = Category3.new
+    @category1s = Category1.all.order("id")
+    # @category2s = Category2.all.order("id")
+    # @category3s = Category3.all.order("id")
+    @brands = Brand.all.order("id")
+  end
+
+  def create
+    @brand = Brand.new(brand_params)
+    if @brand.save
+      @item = Item.new(item_params)
+    else
+      b_id = Brand.find_by(brand_name: @brand.brand_name).id
+      @item = Item.new(item_params)
+      @item["brand_id"] = b_id
+      
+    end
+    @item.save
+    redirect_to new_item_path, notice: "出品しました"
+  end
+  
+  private
+  def brand_params
+    params.require(:brand).permit(:brand_name)
+  end
+  def item_params
+    params.require(:item).permit(:item_name,:brand_name,:category1_id,:explanation,:price,:condition,:sent_charge,:shipping_area,:days_to_ship).merge(user_id: current_user.id, brand_id: @brand.id)
+  end
   
 end

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,2 +1,5 @@
 class Brand < ApplicationRecord
+  validates :brand_name, uniqueness: true
+
+  has_many :items 
 end

--- a/app/models/category1.rb
+++ b/app/models/category1.rb
@@ -1,7 +1,7 @@
 class Category1 < ApplicationRecord
 
-  has_many :category2s
-  has_many :category3s, through: :category2s
-  # has_many :items
+  # has_many :category2s
+  # has_many :category3s, through: :category2s
+  has_many :items
 
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,3 +1,4 @@
 class Item < ApplicationRecord
-  
+  belongs_to :category1
+  belongs_to :brand
 end

--- a/app/views/brand_groups/index.html.haml
+++ b/app/views/brand_groups/index.html.haml
@@ -3,7 +3,7 @@
   .nav
   .category-index
     .visible-pc
-      .gray
+      .category-index__title
         %h2 ブランド一覧
       = render 'brands/category-nav'
       .initial-index
@@ -13,11 +13,14 @@
         .category-index__box__list
           .category-index__box__list__name
             ="#{@category1.category1_name}"
-          .category-index__box__list__inner-box
-            .category-index__box__list__inner-box__name
-            .category-index__box__list__inner-box__sub-box
-              - @category_brands.each do |category_brand|
-                .category-index__box__list__inner-box__sub-box__name
-                  .category23-all
-                    = "#{category_brand[:brand_name]}"
+          - @initials_index.each do |initial|
+            .category-index__box__list__initial-box
+              .category-index__box__list__initial-box__title
+                ="#{initial[:initial]}"
+              .category-index__box__list__initial-box__brand-list
+                - @category_brands.each do |category_brand|
+                  -if "#{initial[:initial]}" == "#{category_brand[:brand_name]}".slice(0)
+                    .category-index__box__list__initial-box__brand-list__name
+                      .category23-all
+                        = "#{category_brand[:brand_name]}"
                     

--- a/app/views/brands/index.html.haml
+++ b/app/views/brands/index.html.haml
@@ -3,7 +3,7 @@
   .nav
   .category-index
     .visible-pc
-      .gray
+      .category-index__title
         %h2 ブランド一覧
       = render 'brands/category-nav'
 

--- a/app/views/category1s/index.html.haml
+++ b/app/views/category1s/index.html.haml
@@ -3,7 +3,7 @@
   .nav
   .category-index
     .visible-pc
-      .gray
+      .category-index__title
         %h2 カテゴリー一覧
       = render 'brands/category-nav'
       .category-index__box

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,83 +1,107 @@
 出品画面
-.sell-container
-  .sell-container__header
-    %h1.list
-      =link_to top_path do
-        = icon('')
 
-  .sell-main
-    .sell-main__item-container
-      .sell-main__item-container__sell-container
-        .sell-main__item-container__sell-container__inner
-          %h2.single-head
-            商品の情報を入力
-            .sell-main__item-container__sell-container__inner__sell-form
-              .sell-main__item-container__sell-container__inner__sell-form__upload-box
-                .sell-main__item-container__sell-container__inner__sell-form__upload-box__head
-                  %h3.sell-upload-head
-                    出品画像
-                  %P 最大10枚までアップロードできます。
-                .sell-main__item-container__sell-container__inner__sell-form__upload-box-image
-                  file uploar
-                .sell-main__item-container__sell-container__inner__sell-form__content
-                  .sell-main__item-container__sell-container__inner__sell-form__content__form-title
-                    =f.label :name, "商品名"
-                    = f.text_field :content, class: 'texterea-default', placeholder: '商品名'
-                  .sell-main__item-container__sell-container__inner__sell-form__content__form-detail
-                    =f.label :name, "商品の説明"
-                    = f.text_field :content, class: 'texterea-default', placeholder: '商品名'
-                .sell-main__item-container__sell-container__inner__sell-form__content.cleafix
-                  %h3.sell-sub-head
-                    商品の詳細
-                  .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box
-                    %li.header__menu-box--left__category
-                    .sell-main__item-container_sell-container__inner__sell-form__content.cleafix__form-box__from-group
-                      = f.label :name, "カテゴリー"
-                      = link_to category_index_path do
-                        .sell-main__item-container_sell-container__inner__sell-form__content.cleafix__form-box__from-group__select-wrap
-                          = fa_icon "list-ul", class: 'header__menu-box--left__icon'
-                            カテゴリーから探す
-                    .sell-main__item-container_sell-container__inner__sell-form__content.cleafix__form-box__from-group
-                      = f.label :name, "商品の状態"
-                      = link_to category_index_path do
-                        .sell-main__item-container_sell-container__inner__sell-form__content.cleafix__form-box__from-group__select-wrap
-                          = fa_icon "list-ul", class: 'header__menu-box--left__icon'                   
-                .sell-main__item-container__sell-container__inner__sell-form__content.cleafix
-                  %h3.sell-sub-head
-                    配送について
-                  .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box
-                    .sell-main__item-container_sell-container__inner__sell-form__content.cleafix__form-box__from-group
-                      = f.label :name, "商品の状態"
-                      = link_to category_index_path do
-                        .sell-main__item-container_sell-container__inner__sell-form__content.cleafix__form-box__from-group__select-wrap
-                          = fa_icon "list-ul", class: 'header__menu-box--left__icon' 
+= form_for([@item], html: {class: "item-out"}) do |f|
 
-                .sell-main__item-container__sell-container__inner__sell-form__content.cleafix
-                  %h3.sell-sub-head
-                    販売価格
-                  .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box
-                    %ul.sell-price
-                    /= f.label :name, "価格" class, l-left
-                    .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box__sell-price-input
-                      ¥
-                      = f.text_field :content, class: 'input-default', placeholder: '例)300'
-                  .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box__cleafix
-                    .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box__cleafix__l-left
-                      販売手数料(10%)
-                    .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box__cleafix__l-right
-                  .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box__cleafix.bold
-                    .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box__cleafix.bold__l-left
-                      販売利益
-                    .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box__cleafix.bold__l-right
+  = f.text_field :item_name, placeholder: "商品名"
+  
+  = f.collection_select(:category1_id, @category1s, :id, :category1_name, {prompt: "カテゴリー1"})
+  -# = f.collection_select(:category2_id, @category2s, :id, :category2_name, {prompt: "カテゴリー2"})
+  -# = f.collection_select(:category3_id, @category3s, :id, :category3_name, {prompt: "カテゴリー3"})
+  = form_for([@brand], html: {class: "item-out"}) do |f|
+    = f.text_field :brand_name, placeholder: "ブランド名"
+    -# = f.submit "ブランド名を登録"
+    = form_for([@item], html: {class: "item-out"}) do |f|
+      -# = f.collection_select(:brand_id, @brands, :id, :brand_name, {prompt: "ブランドを選択"})
+      = f.text_area :explanation, placeholder: "紹介文"
+      = f.number_field :price, placeholder: "値段"
+      = f.select :condition, [["新品、未使用",0], ["未使用に近い", 1], ["目立った傷や汚れなし", 2], ["やや傷や汚れあり", 3], ["傷や汚れあり", 4], ["全体的に状態が悪い", 5]], prompt: "商品の状態"
+      = f.select :sent_charge, [["送料込み（出品者負担）",0], ["着払い（購入者負担）", 1]], prompt: "配送料の負担"
+      = f.select :shipping_area, [["北海道"], ["青森県"]], prompt: "発送元の地域"
+      = f.select :days_to_ship, [["１〜２日で発送",0], ["3〜4日で発送", 1], ["4〜7日で発送", 2]], prompt: "発送までの日数"
+    
+      = f.submit "出品"
+
+
+
+-# .sell-container
+-#   .sell-container__header
+-#     %h1.list
+-#       =link_to top_path do
+-#         = icon('')
+
+-#   .sell-main
+-#     .sell-main__item-container
+-#       .sell-main__item-container__sell-container
+-#         .sell-main__item-container__sell-container__inner
+-#           %h2.single-head
+-#             商品の情報を入力
+-#             .sell-main__item-container__sell-container__inner__sell-form
+-#               .sell-main__item-container__sell-container__inner__sell-form__upload-box
+-#                 .sell-main__item-container__sell-container__inner__sell-form__upload-box__head
+-#                   %h3.sell-upload-head
+-#                     出品画像
+-#                   %P 最大10枚までアップロードできます。
+-#                 .sell-main__item-container__sell-container__inner__sell-form__upload-box-image
+-#                   file uploar
+-#                 .sell-main__item-container__sell-container__inner__sell-form__content
+-#                   .sell-main__item-container__sell-container__inner__sell-form__content__form-title
+-#                     =f.label :name, "商品名"
+-#                     = f.text_field :content, class: 'texterea-default', placeholder: '商品名'
+-#                   .sell-main__item-container__sell-container__inner__sell-form__content__form-detail
+-#                     =f.label :name, "商品の説明"
+-#                     = f.text_field :content, class: 'texterea-default', placeholder: '商品名'
+-#                 .sell-main__item-container__sell-container__inner__sell-form__content.cleafix
+-#                   %h3.sell-sub-head
+-#                     商品の詳細
+-#                   .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box
+-#                     %li.header__menu-box--left__category
+-#                     .sell-main__item-container_sell-container__inner__sell-form__content.cleafix__form-box__from-group
+-#                       = f.label :name, "カテゴリー"
+-#                       = link_to category_index_path do
+-#                         .sell-main__item-container_sell-container__inner__sell-form__content.cleafix__form-box__from-group__select-wrap
+-#                           = fa_icon "list-ul", class: 'header__menu-box--left__icon'
+-#                             カテゴリーから探す
+-#                     .sell-main__item-container_sell-container__inner__sell-form__content.cleafix__form-box__from-group
+-#                       = f.label :name, "商品の状態"
+-#                       = link_to category_index_path do
+-#                         .sell-main__item-container_sell-container__inner__sell-form__content.cleafix__form-box__from-group__select-wrap
+-#                           = fa_icon "list-ul", class: 'header__menu-box--left__icon'                   
+-#                 .sell-main__item-container__sell-container__inner__sell-form__content.cleafix
+-#                   %h3.sell-sub-head
+-#                     配送について
+-#                   .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box
+-#                     .sell-main__item-container_sell-container__inner__sell-form__content.cleafix__form-box__from-group
+-#                       = f.label :name, "商品の状態"
+-#                       = link_to category_index_path do
+-#                         .sell-main__item-container_sell-container__inner__sell-form__content.cleafix__form-box__from-group__select-wrap
+-#                           = fa_icon "list-ul", class: 'header__menu-box--left__icon' 
+
+-#                 .sell-main__item-container__sell-container__inner__sell-form__content.cleafix
+-#                   %h3.sell-sub-head
+-#                     販売価格
+-#                   .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box
+-#                     %ul.sell-price
+-#                     /= f.label :name, "価格" class, l-left
+-#                     .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box__sell-price-input
+-#                       ¥
+-#                       = f.text_field :content, class: 'input-default', placeholder: '例)300'
+-#                   .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box__cleafix
+-#                     .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box__cleafix__l-left
+-#                       販売手数料(10%)
+-#                     .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box__cleafix__l-right
+-#                   .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box__cleafix.bold
+-#                     .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box__cleafix.bold__l-left
+-#                       販売利益
+-#                     .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__form-box__cleafix.bold__l-right
                     
-                .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__sell-btn-box
-                  .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__sell-btn-box__red-btn
-                    = link to "registrations/new", type = "button"
-                      出品する
-                  .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__sell-btn-box__gray-btn
-                    /= link to :back do, type = "button"
+-#                 .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__sell-btn-box
+-#                   .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__sell-btn-box__red-btn
+-#                     = link to "registrations/new", type = "button"
+-#                       出品する
+-#                   .sell-main__item-container__sell-container__inner__sell-form__content.cleafix__sell-btn-box__gray-btn
+-#                     /= link to :back do, type = "button"
                 
-  .sell-footer
-    .sell-footer__logo
-      =link_to top_path do
-        = icon('')
+-#   .sell-footer
+-#     .sell-footer__logo
+-#       =link_to top_path do
+-#         = icon('')

--- a/db/migrate/20200204140542_create_brands.rb
+++ b/db/migrate/20200204140542_create_brands.rb
@@ -1,7 +1,7 @@
 class CreateBrands < ActiveRecord::Migration[5.2]
   def change
     create_table :brands do |t|
-      t.string :brand_name,null: false, index: true
+      t.string :brand_name,null: false, unique: true, index: true
       
     end
   end

--- a/db/migrate/20200204154903_create_items.rb
+++ b/db/migrate/20200204154903_create_items.rb
@@ -1,15 +1,16 @@
 class CreateItems < ActiveRecord::Migration[5.2]
   def change
     create_table :items do |t|
-      t.string :item_name,null: false, index: true      #商品名
-      t.text :explanation,null: false                   #説明
-      t.integer :price,null: false                      #価格
-      t.string :condition,null: false                   #状態（選択式）
-      t.boolean :sent_charge,null: false                #配送料の負担
-      t.string :shipping_area,null: false               #発送元の地域（選択式）
-      t.string :days_to_ship,null: false                #発送までの日数（選択式）
-      t.references :user, foreign_key: true             #出品者
-      t.references :brand, foreign_key: true            #ブランド
+      t.string :item_name,null: false, index: true          #商品名
+      t.text :explanation,null: false    #説明
+      t.integer :price,null: false        #価格
+      t.string :size                      #サイズ
+      t.string :condition,null: false     #状態（選択式）
+      t.string :sent_charge,null: false  #配送料の負担
+      t.string :shipping_area,null: false  #発送元の地域（選択式）
+      t.string :days_to_ship,null: false  #発送までの日数（選択式）
+      t.references :user, foreign_key: true #出品者
+      t.references :brand, foreign_key: true #ブランド
       t.references :category1, foreign_key: true
       t.references :category2, foreign_key: true
       t.references :category3, foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,8 +57,9 @@ ActiveRecord::Schema.define(version: 2020_02_04_154905) do
     t.string "item_name", null: false
     t.text "explanation", null: false
     t.integer "price", null: false
+    t.string "size"
     t.string "condition", null: false
-    t.boolean "sent_charge", null: false
+    t.string "sent_charge", null: false
     t.string "shipping_area", null: false
     t.string "days_to_ship", null: false
     t.bigint "user_id"


### PR DESCRIPTION
#what
仮の出品フォーム実装
入力フォームだけ設置
ブランドテーブルに一意性導入
同じbrand_nameを保存しようとfind_byによってBrandテーブルからidを取得
取得したidをitemのbrand_idとして保存
一度マイグレートをロールバックしてrails db:migrateする必要あり
元のitem/newのhtmlはコメントアウトして残してあります