### PR TITLE
PurchaseのDB保存処理追加

### DIFF
--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -10,7 +10,7 @@ class PurchaseController < ApplicationController
         redirect_to root_path
 
       elsif @card.blank?
-        redirect_to new_card_path, notice: "クレジットカードを登録してください"
+        redirect_to new_card_path, alert: "クレジットカードを登録してください"
 
       else
         Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
@@ -30,6 +30,7 @@ class PurchaseController < ApplicationController
     customer: @card.customer_id,
     currency: 'jpy',
     )
+    Purchase.create(item_id: @item.id, user_id: current_user.id)
     @trading = @item.trading
     @trading.status = false
     @trading.save

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -7,15 +7,16 @@ class PurchaseController < ApplicationController
 
   def index
     if @item.trading.status == false
-      redirect_to root_path
-    end
-    if @card.blank?
-      redirect_to new_card_path 
-    else
-      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-      customer = Payjp::Customer.retrieve(@card.customer_id)
-      @default_card = customer.cards.retrieve(@card.card_id)
-      @image = @item.images.first
+        redirect_to root_path
+
+      elsif @card.blank?
+        redirect_to new_card_path, notice: "クレジットカードを登録してください"
+
+      else
+        Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+        customer = Payjp::Customer.retrieve(@card.customer_id)
+        @default_card = customer.cards.retrieve(@card.card_id)
+        @image = @item.images.first
     end
   end
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1,4 +1,4 @@
 class Purchase < ApplicationRecord
   belongs_to :item
-  belongs_to :users
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,6 @@ class User < ApplicationRecord
   has_many :items
   has_many :tradings
   has_many :favorites, dependent: :destroy
-  has_many :purchase
+  has_many :purchases
 
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -13,4 +13,5 @@
     = javascript_include_tag 'application'
     = include_gon
   %body
+    = render 'layouts/notifications'
     = yield


### PR DESCRIPTION
# What
購入時PurchaseDBに`item_id`と`user_id`を保存する。

# Why
どのユーザーが何を購入したか管理できるようにする為。

# Notes
フラッシュメッセージの`render`追加だけ行いました。