### PR TITLE
商品あいまい検索機能の実装

### DIFF
--- a/app/assets/stylesheets/modules/_search.scss
+++ b/app/assets/stylesheets/modules/_search.scss
@@ -4,9 +4,11 @@
   height: 100%;
   padding: 50px 100px;
   &__lists {
+    max-width: 940px;
+    margin: 0 auto;
     display: grid;
     grid-template-columns: repeat(auto-fit, 220px);
-    column-gap: 8px;
+    column-gap: 10px;
     row-gap: 20px;
     justify-content: space-between;
   }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -85,7 +85,12 @@ class ItemsController < ApplicationController
   end
 
   def search
-    @items = Item.all.order("id DESC")
+    @items = Item.none
+    @keywords = params[:key].split(/[[:blank:]]+/).select(&:present?)
+    @keywords.each do |keyword|
+      @items = @items.or(Item.where("name LIKE ?", "%#{keyword}%"))
+    end
+    @items = @items.order("id DESC")
     @itemImage = {}
     @items.each do |item|
       @itemImage[:"#{item.id}"] = item.images.first

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -89,6 +89,8 @@ class ItemsController < ApplicationController
     @items = Item.none
     # 検索キーワードをスペースで分割してインスタンス化
     @keywords = params[:key].split(/[[:blank:]]+/).select(&:present?)
+    # 検索キーワードが空の場合はリダイレクト
+    redirect_to root_path, alert: "検索キーワードが空白です" if @keywords.blank?
     # 分割したキーワード毎にItemDBを検索してインスタンスにセット
     @keywords.each do |keyword|
       @items = @items.or(Item.where("name LIKE ?", "%#{keyword}%"))

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -85,8 +85,11 @@ class ItemsController < ApplicationController
   end
 
   def search
+    # 空のItemモデルを作成
     @items = Item.none
+    # 検索キーワードをスペースで分割してインスタンス化
     @keywords = params[:key].split(/[[:blank:]]+/).select(&:present?)
+    # 分割したキーワード毎にItemDBを検索してインスタンスにセット
     @keywords.each do |keyword|
       @items = @items.or(Item.where("name LIKE ?", "%#{keyword}%"))
     end

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -10,11 +10,9 @@
         フリマアプリです
       .main__visual__contents__btn
         .main__visual__contents__btn--icon
-          = link_to new_card_path do
-            = image_tag 'logo/app-store-badge.svg'
+          = image_tag 'logo/app-store-badge.svg'
         .main__visual__contents__btn--icon
-          = link_to '/card/show' do
-            = image_tag 'logo/google-play-badge.svg'
+          = image_tag 'logo/google-play-badge.svg'
   .main__intro
     .main__intro--subtitle
       FURIMAが選ばれる3つの理由
@@ -59,8 +57,7 @@
         ほしかったあの商品に出会えるかもしれません。
       .main__middle-visual__contents__btn
         .main__middle-visual__contents__btn--icon
-          = link_to '/purchase' do
-            = image_tag 'logo/app-store-badge.svg'
+          = image_tag 'logo/app-store-badge.svg'
         .main__middle-visual__contents__btn--icon
           = image_tag 'logo/google-play-badge.svg'
   .main__features

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -1,6 +1,11 @@
 = render 'shared/header'
 
 .searchPickupArea
+  %ul.parts-nav
+    %li
+      - @keywords.each do |keyword|
+        = keyword + " "
+      の検索結果
   %ul.searchPickupArea__lists
     - @items.each do |item|
       - if item.trading.status == true

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -12,13 +12,6 @@
             = label_tag :icon__search do
               .header__main__form__search--icon
                 = image_tag 'icon/icon-search 1.png'
-        -# = form_with(model: @items, url: search_items_path, local: true) do |f|
-        -#   .header__main__form__search
-        -#     = f.text_field :name, class: '.header__main__form__search--box', placeholder: 'キーワードから探す'
-        -#     = f.submit '', class: '.header__main__form__search--btn', id: "icon__search"
-        -#     = f.label :icon__search do
-        -#       .header__main__form__search--icon
-        -#         = image_tag 'icon/icon-search 1.png'
     .header__nav
       %ul.header__nav__left
         %li.header__nav__left--category


### PR DESCRIPTION
# What
商品をキーワードであいまい検索できるようにする。

# Why
ユーザーが欲しい商品を商品名から検索できるようにする。

# Notes
- 空白の場合はトップページへリダイレクトさせる
- キーワード内に空白が存在した場合は、`or`の判定とする