### PR TITLE
Address

### DIFF
--- a/app/assets/stylesheets/modules/_header.scss
+++ b/app/assets/stylesheets/modules/_header.scss
@@ -87,7 +87,7 @@
       display: flex;
 
       &--usermenu {
-        padding-left: 16px;
+        padding-left: 35px;
       }
     }
   }

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -19,7 +19,7 @@ class AddressesController < ApplicationController
   end
 
   def edit
-    @address = User.find(params[:id]).address
+    @address = User.find(current_user.id).address
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,10 @@
 class UsersController < ApplicationController
   before_action :set_items, only: [:index, :listings_purchased]
   before_action :set_purchase, only: [:index, :purchase, :purchased]
+  before_action :set_address
   
+  
+
   def index
     @items = @purchases.map {|purchase| purchase.item }
   end
@@ -45,4 +48,10 @@ class UsersController < ApplicationController
     @purchases = Purchase.where(user_id: current_user.id)
     @items = @purchases.map {|purchase| purchase.item }
   end
+
+  def set_address
+    @address = User.find(current_user.id).address
+  end
+
+
 end

--- a/app/views/addresses/edit.html.haml
+++ b/app/views/addresses/edit.html.haml
@@ -1,4 +1,6 @@
 = render 'shared/header'
+- breadcrumb :address_edit
+= render "layouts/breadcrumbs"
 .add-container
   .add-content
     %h2 発送元・お届け先住所編集

--- a/app/views/addresses/new.html.haml
+++ b/app/views/addresses/new.html.haml
@@ -1,6 +1,8 @@
 = render 'shared/header'
+- breadcrumb :address_new
+= render "layouts/breadcrumbs"
 .add-container
   .add-content
-    %h2 発送元・お届け先住所登録
+    %h2 発送元・お届け先住所
     = render partial: 'form', locals: { address: @address }
 = render 'shared/footer'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -4,7 +4,7 @@
     .signin-main__box
       .signin-main__box--login
         %p アカウントをお持ちでない方はこちら
-        = link_to "新規会員登録", new_user_path
+        = link_to "新規会員登録", new_user_registration_path
       .signin-main__box--link
         #facebook-login
           %i.fab.fa-facebook-square

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -28,9 +28,6 @@
             = link_to users_path, class:"header__nav--textBtn" do
               マイページ
           %li.header__nav__right--usermenu
-            = link_to edit_address_path(current_user), class:"header__nav--textBtn" do
-              登録編集
-          %li.header__nav__right--usermenu
             = link_to destroy_user_session_path, class:"header__nav--textBtn", method: :delete do
               ログアウト
         - else
@@ -38,6 +35,5 @@
             = link_to new_user_session_path, class:"header__nav--textBtn" do
               ログイン
           %li.header__nav__right--usermenu
-
             = link_to new_user_registration_path, class:"header__nav--textBtn" do
               新規会員登録

--- a/app/views/users/_mypage-leftcontent.haml
+++ b/app/views/users/_mypage-leftcontent.haml
@@ -30,8 +30,12 @@
       = link_to new_card_path do
         %input{type:"button", value:"クレジットカード登録・編集"}
     .maincontainer__leftcontent__navi__tablist
-      = link_to new_address_path  do
-        %input{type:"button", value:"発送元・お届け先住所登録"}
+      -if @address.blank?
+        = link_to new_address_path do
+          %input{type:"button", value:"発送元・お届け先住所登録"}
+      -else
+        = link_to edit_address_path(@address) do
+          %input{type:"button", value:"発送元・お届け先住所編集"}
     .maincontainer__leftcontent__navi__tablist
       = link_to destroy_user_session_path do
         %input{type:"button", value:"ログアウト"}

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -57,3 +57,13 @@ crumb :card_new do
   link "クレジットカード新規登録", new_card_path
   parent :users_index
 end
+
+crumb :address_new do
+  link "発送元・お届け先住所／新規登録", new_address_path
+  parent :users_index
+end
+
+crumb :address_edit do
+  link "発送元・お届け先住所／編集", edit_address_path
+  parent :users_index
+end


### PR DESCRIPTION
#What
ログイン時と未ログイン時で、編集画面か登録画面かに分岐
他のページのビューに合わせて統一感を出すためパンくずリストを実装
#Why
発送元の登録編集が簡易にできるようにする